### PR TITLE
Fix incompatibility with the grizzly nova schedular

### DIFF
--- a/akanda/nova/quantumv2/api.py
+++ b/akanda/nova/quantumv2/api.py
@@ -77,7 +77,7 @@ class API(api.API):
         created_port_ids = []
         for network in nets:
             network_id = network['id']
-            zone = 'compute:%s' % CONF.node_availability_zone
+            zone = 'compute:%s' % CONF.default_availability_zone
             port_req_body = {'device_id': instance['uuid']}
             try:
                 port = ports.get(network_id)

--- a/akanda/nova/virt/libvirt.py
+++ b/akanda/nova/virt/libvirt.py
@@ -3,11 +3,12 @@ from nova.virt.libvirt import driver
 
 
 class LibvirtDriver(driver.LibvirtDriver):
-    def get_guest_config(self, instance, network_info, image_meta, rescue=None,
-                         block_device_info=None):
+    def get_guest_config(self, instance, network_info, image_meta, disk_info,
+                         rescue=None, block_device_info=None):
         guest = super(LibvirtDriver, self).get_guest_config(instance,
                                                             network_info,
                                                             image_meta,
+                                                            disk_info,
                                                             rescue,
                                                             block_device_info)
 


### PR DESCRIPTION
DHC-1018
- Fix problem due to CONF.node_availability_zone renaming to
  CONF.default_availability_zone
- Fix change in nova API that was causing our overridden
  get_guest_config method to accept a wrong number of argument

Change-Id: I241651f40b3d0381da9381d94d06d7051c7d0fad
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
