### PR TITLE
Configure tox to use flake8 instead of pep8 and pyflakes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,14 @@
 [tox]
-envlist = py27,pep8,pyflakes
+envlist = py27,style
 
 [testenv]
 deps = -r{toxinidir}/test_requirements.txt
 commands = nosetests {posargs}
 sitepackages = False
 
-[tox:jenkins]
-
-[testenv:pep8]
-deps = pep8
-commands = pep8 --repeat --show-source --ignore=E125 --exclude=.venv,.tox,dist,doc,*egg .
+[testenv:style]
+deps = flake8
+commands = flake8 akanda test setup.py
 
 [testenv:cover]
 setenv = NOSE_WITH_COVERAGE=1
@@ -18,6 +16,8 @@ setenv = NOSE_WITH_COVERAGE=1
 [testenv:venv]
 commands = {posargs}
 
-[testenv:pyflakes]
-deps = pyflakes
-commands = pyflakes akanda
+[flake8]
+ignore = E125
+show-source = true
+statistics = true
+builtins = _


### PR DESCRIPTION
Change-Id: I5c895c44543978c869aa706e3e1e5ba170180976
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
